### PR TITLE
Fix: Resolve Gradio InvalidComponentError on login

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,7 +115,7 @@ def clear_admin_form_fields_action() -> tuple:
 def handle_signup_action(email: str, pw: str, conf_pw: str) -> str:
     return signup_user(supabase_client, email, pw, conf_pw)
 
-def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame, current_main_tabs: gr.Tabs) -> tuple:
+def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame) -> tuple:
     sess_data, msg = login_user(supabase_client, email, pw)
     role = get_user_role(sess_data, ADMIN_EMAIL)
     if sess_data:
@@ -127,7 +127,7 @@ def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame,
         return msg, sess_data, gr.update(visible=False), gr.update(True), gr.update(visible=False), gr.update(visible=True if role == 'admin' else False), gr.Tabs(selected="management_tab" if role == 'admin' else "search_tab"), df_admin_equip_val, msg_admin_equip_val
     else:
         gr.Error(msg)
-        return msg, None, gr.update(visible=True), gr.update(visible=False), gr.update(visible=True), gr.update(visible=False), current_main_tabs, current_admin_df, ""
+        return msg, None, gr.update(visible=True), gr.update(visible=False), gr.update(visible=True), gr.update(visible=False), gr.update(), current_admin_df, ""
 
 def universal_logout_ui_updates(curr_sess: Any) -> tuple:
     logout_msg, new_sess, sel_eq_cleared = logout_user(supabase_client, curr_sess)
@@ -245,7 +245,7 @@ if __name__ == "__main__":
 
             # --- Auth Event Handlers ---
             signup_button.click(handle_signup_action, inputs=[signup_email_input, signup_password_input, signup_confirm_password_input], outputs=[signup_status_output])
-            login_button.click(handle_login_ui_updates, inputs=[login_email_input, login_password_input, admin_all_equipments_df_state, main_tabs], outputs=[login_status_output, user_session_var, auth_forms_group, user_info_group, auth_tab_item_obj, admin_management_tab_item_obj, main_tabs, admin_all_equipments_df_state, admin_status_output])
+            login_button.click(handle_login_ui_updates, inputs=[login_email_input, login_password_input, admin_all_equipments_df_state], outputs=[login_status_output, user_session_var, auth_forms_group, user_info_group, auth_tab_item_obj, admin_management_tab_item_obj, main_tabs, admin_all_equipments_df_state, admin_status_output])
             logout_button_auth_tab.click(universal_logout_ui_updates, inputs=[user_session_var], outputs=[logout_status_auth_tab_output, user_session_var, auth_forms_group, user_info_group, auth_tab_item_obj, admin_management_tab_item_obj, main_tabs, selected_equipment_to_rent_var, admin_all_equipments_df_state, selected_equipment_for_edit_state, admin_edit_id_input, admin_edit_name_input, admin_edit_dept_dropdown, admin_edit_qty_input, admin_status_output])
             logout_button_admin_tab.click(universal_logout_ui_updates, inputs=[user_session_var], outputs=[logout_status_admin_tab_output, user_session_var, auth_forms_group, user_info_group, auth_tab_item_obj, admin_management_tab_item_obj, main_tabs, selected_equipment_to_rent_var, admin_all_equipments_df_state, selected_equipment_for_edit_state, admin_edit_id_input, admin_edit_name_input, admin_edit_dept_dropdown, admin_edit_qty_input, admin_status_output])
             user_session_var.change(update_user_display, inputs=[user_session_var], outputs=[current_user_display])

--- a/modify_app.py
+++ b/modify_app.py
@@ -1,0 +1,73 @@
+# Read app.py
+with open("app.py", "r") as f:
+    content = f.read()
+
+# Modify login_button.click inputs
+# Original: inputs=[login_email_input, login_password_input, admin_all_equipments_df_state, main_tabs]
+# New:      inputs=[login_email_input, login_password_input, admin_all_equipments_df_state]
+content = content.replace(
+    "login_button.click(handle_login_ui_updates, inputs=[login_email_input, login_password_input, admin_all_equipments_df_state, main_tabs]",
+    "login_button.click(handle_login_ui_updates, inputs=[login_email_input, login_password_input, admin_all_equipments_df_state]"
+)
+
+# Modify handle_login_ui_updates function definition
+# Original: def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame, current_main_tabs: gr.Tabs) -> tuple:
+# New:      def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame) -> tuple:
+content = content.replace(
+    "def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame, current_main_tabs: gr.Tabs) -> tuple:",
+    "def handle_login_ui_updates(email: str, pw: str, current_admin_df: pd.DataFrame) -> tuple:"
+)
+
+# Modify the return statement in the else block of handle_login_ui_updates for main_tabs output
+# Original line (part of a tuple): current_main_tabs,
+# We need to find the specific return tuple for the failure case.
+# It looks like:
+# return msg, None, gr.update(visible=True), gr.update(visible=False), gr.update(visible=True), gr.update(visible=False), current_main_tabs, current_admin_df, ""
+# The 7th element is current_main_tabs. It should become gr.update()
+# This is fragile if the number of returned elements changes. A more robust way would be to parse the AST or use regex with care.
+# For now, using a targeted string replacement that assumes the structure.
+
+# Let's try a more specific replacement for the return tuple in the else block
+original_failure_return_tuple = 'msg, None, gr.update(visible=True), gr.update(visible=False), gr.update(visible=True), gr.update(visible=False), current_main_tabs, current_admin_df, ""'
+new_failure_return_tuple = 'msg, None, gr.update(visible=True), gr.update(visible=False), gr.update(visible=True), gr.update(visible=False), gr.update(), current_admin_df, ""'
+
+content = content.replace(original_failure_return_tuple, new_failure_return_tuple)
+
+# Write the modified content back to app.py
+with open("app.py", "w") as f:
+    f.write(content)
+
+print("app.py modified to fix InvalidComponentError for login button.")
+# Verify the changes by printing relevant snippets
+print("\n--- Verifying login_button.click ---")
+with open("app.py", "r") as f:
+    for line in f:
+        if "login_button.click" in line:
+            print(line.strip())
+            break # Show first occurrence
+
+print("\n--- Verifying handle_login_ui_updates definition ---")
+with open("app.py", "r") as f:
+    for line in f:
+        if "def handle_login_ui_updates" in line:
+            print(line.strip())
+            break
+
+print("\n--- Verifying handle_login_ui_updates failure return ---")
+# This is harder to grep simply, but the change should be applied.
+# We can search for the new tuple structure.
+with open("app.py", "r") as f:
+    for line in f:
+        if new_failure_return_tuple in line:
+            print("Found new failure return tuple snippet:")
+            print(line.strip())
+            break
+    else: # If loop finishes without break
+        print("Could not find the new failure return tuple snippet. Manual check might be needed or original was slightly different.")
+        print("Searching for parts of it:")
+        with open("app.py", "r") as f_recheck:
+            for line_recheck in f_recheck:
+                if "gr.update(), current_admin_df," in line_recheck:
+                    print("Found partial match for new failure return:")
+                    print(line_recheck.strip())
+                    break


### PR DESCRIPTION
Corrects an `InvalidComponentError` that occurred when clicking the login button. The error was caused by incorrectly using `gr.Tabs` (main_tabs) as an input component in the login event handler.

Changes made:
- Removed `main_tabs` from the `inputs` list of the `login_button.click` event.
- Updated the `handle_login_ui_updates` function to remove the corresponding parameter.
- Ensured that on login failure, `gr.update()` is used for the `main_tabs` output slot, meaning the tabs' state will not change, which is the desired behavior.